### PR TITLE
Issue #35: Avoid hard-coded module path in template.

### DIFF
--- a/collabora_online.module
+++ b/collabora_online.module
@@ -64,6 +64,7 @@ function collabora_online_theme($existing, $type, $theme, $path) {
               'wopiSrc' => '/wopi/files/123',
               'wopiClient' => 'https://localhost:9980/',
           ],
+          'file' => 'collabora_online.theme.inc',
       ],
   ];
 

--- a/collabora_online.module
+++ b/collabora_online.module
@@ -33,7 +33,6 @@ function collabora_online_theme($existing, $type, $theme, $path) {
       'collabora_online' => [
           'render element' => 'children',
           'template' => 'collabora-online',
-          'path' => $path . '/templates',
           'variables' => [
               'accessToken' => 'test',
               'accessTokenTtl' => '86400',
@@ -48,7 +47,6 @@ function collabora_online_theme($existing, $type, $theme, $path) {
       'collabora_online_preview' => [
           'render element' => 'children',
           'template' => 'collabora-online-preview',
-          'path' => $path . '/templates',
           'variables' => [
               'editorUrl' => 'about:blank',
               'fileName' => '',
@@ -57,7 +55,6 @@ function collabora_online_theme($existing, $type, $theme, $path) {
       // This is the template for the complete page with embedding.
       'collabora_online_full' => [
           'template' => 'collabora-online-full',
-          'path' => $path . '/templates',
           'variables' => [
               'accessToken' => 'test',
               'accessTokenTtl' => '86400',

--- a/collabora_online.theme.inc
+++ b/collabora_online.theme.inc
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Preprocess functions for this module.
+ */
+
+use Drupal\Core\Extension\ExtensionPathResolver;
+
+/**
+ * Prepares variables for the 'collabora-online-full' template.
+ *
+ * @param array $variables
+ *   Theme hook variables.
+ */
+function template_preprocess_collabora_online_full(array &$variables): void {
+    /** @var \Drupal\Core\Extension\ExtensionPathResolver $path_resolver */
+    $path_resolver = \Drupal::service(ExtensionPathResolver::class);
+    $variables['module_path'] = $path_resolver->getPath('module', 'collabora_online');
+}

--- a/templates/collabora-online-full.html.twig
+++ b/templates/collabora-online-full.html.twig
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <script src="/modules/contrib/collabora_online/js/cool.js"></script>
-    <link href="/modules/contrib/collabora_online/css/cool.css" rel="stylesheet" />
+    <script src="{{ file_url(module_path ~ '/js/cool.js') }}"></script>
+    <link href="{{ file_url(module_path ~ '/css/cool.css') }}" rel="stylesheet" />
   </head>
   <body class="cool-editor__body">
     {{ include('collabora-online.html.twig') }}


### PR DESCRIPTION
Fixes #35.

This uses the simple / least disruptive option with a preprocess hook.

I placed the preprocess hook in a separate file, to avoid merge conflicts with other pending branches.
To do this, I had to remove the 'path' setting from the theme hook.
It seemed to be useless anyway, the templates are found without this setting.

Testing:
- Visit `/cool/edit/{...}`...
- ... in a regular Drupal installation where the module is in `modules/contrib/collabora_online/`.
- ... where the module is in `modules/custom/collabora_online/` or `modules/custom/online/` (alternative module name).
- ... where Drupal is installed in a subdirectory like `http://localhost/web/`.

Check the page source, make sure the two urls look ok.