### PR TITLE
Issue #43: Code style fixes, without comment changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,10 @@ jobs:
         run: |
           docker-compose exec -T web composer install --no-interaction
 
+      - name: PhpCS
+        run: |
+          docker-compose exec -T web ./vendor/bin/phpcs -s
+
       - name: Drupal site install
         run: |
           docker-compose exec -T web ./vendor/bin/run drupal:site-install

--- a/collabora_online.module
+++ b/collabora_online.module
@@ -102,7 +102,7 @@ function collabora_online_entity_operation(EntityInterface $entity) {
         'collabora_online_view' => [
             'title' => t("View in Collabora Online"),
             'weight' => 50,
-            'url' => CoolUtils::getEditorUrl($media, false),
+            'url' => CoolUtils::getEditorUrl($media, FALSE),
         ],
     ];
 
@@ -110,7 +110,7 @@ function collabora_online_entity_operation(EntityInterface $entity) {
         $entries['collabora_online_edit'] = [
             'title' => t("Edit in Collabora Online"),
             'weight' => 50,
-            'url' => CoolUtils::getEditorUrl($media, true),
+            'url' => CoolUtils::getEditorUrl($media, TRUE),
         ];
     }
 

--- a/collabora_online.module
+++ b/collabora_online.module
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright the Collabora Online contributors.
  *
@@ -69,7 +70,6 @@ function collabora_online_theme($existing, $type, $theme, $path) {
           'file' => 'collabora_online.theme.inc',
       ],
   ];
-
 }
 
 /**

--- a/collabora_online.module
+++ b/collabora_online.module
@@ -46,7 +46,7 @@ function collabora_online_theme($existing, $type, $theme, $path) {
               'wopiClient' => 'https://localhost:9980/',
           ],
       ],
-      // This is the template for the field preview
+      // This is the template for the field preview.
       'collabora_online_preview' => [
           'render element' => 'children',
           'template' => 'collabora-online-preview',

--- a/collabora_online.module
+++ b/collabora_online.module
@@ -103,7 +103,7 @@ function collabora_online_entity_operation(EntityInterface $entity) {
             'title' => t("View in Collabora Online"),
             'weight' => 50,
             'url' => CoolUtils::getEditorUrl($media, false),
-        ]
+        ],
     ];
 
     if (CoolUtils::canEdit($file) && $media->access('edit in collabora')) {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="DrupalCollaboraOnline">
+  <description>Modified PHP CodeSniffer configuration based on Drupal.</description>
+
+  <arg name="extensions" value="inc,install,module,php,theme,yml,json"/>
+
+  <exclude-pattern>./vendor/*</exclude-pattern>
+  <exclude-pattern>./web/*</exclude-pattern>
+  <file>.</file>
+
+  <rule ref="vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml">
+    <!-- Accept 4 spaces of indentation for now. -->
+    <exclude name="Drupal.WhiteSpace.ScopeIndent"/>
+    <exclude name="Drupal.Arrays.Array.ArrayIndentation"/>
+    <exclude name="Drupal.Functions.MultiLineFunctionDeclaration.Indent"/>
+    <exclude name="Drupal.WhiteSpace.ScopeClosingBrace.BreakIndent"/>
+    <exclude name="Drupal.WhiteSpace.ScopeClosingBrace.Indent"/>
+    <exclude name="Drupal.WhiteSpace.ObjectOperatorIndent.Indent"/>
+    <!-- Accept file doc comment with copyright. -->
+    <exclude name="Drupal.Commenting.FileComment.NamespaceNoFileDoc"/>
+    <exclude name="Drupal.Commenting.FileComment.WrongStyle"/>
+    <!-- Accept imports order from PhpStorm. -->
+    <exclude name="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses.IncorrectlyOrderedUses"/>
+    <!-- Keep existing identifiers, as renaming would be disruptive. -->
+    <exclude name="Drupal.NamingConventions.ValidFunctionName.InvalidName"/>
+    <exclude name="Drupal.NamingConventions.ValidVariableName.LowerCamelName"/>
+    <exclude name="Drupal.NamingConventions.ValidFunctionName.ScopeNotCamelCaps"/>
+
+    <!-- Fix doc comments later. -->
+    <exclude name="Drupal.Commenting.ClassComment"/>
+    <exclude name="Drupal.Commenting.DataTypeNamespace"/>
+    <exclude name="Drupal.Commenting.DocComment"/>
+    <exclude name="Drupal.Commenting.FunctionComment"/>
+    <exclude name="Drupal.Commenting.VariableComment"/>
+
+    <!-- Fix translatable strings later. -->
+    <exclude name="Drupal.Semantics.FunctionT.WhiteSpace"/>
+  </rule>
+</ruleset>

--- a/src/CollaboraMediaPermissions.php
+++ b/src/CollaboraMediaPermissions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright the Collabora Online contributors.
  *

--- a/src/Controller/ViewerController.php
+++ b/src/Controller/ViewerController.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright the Collabora Online contributors.
  *
@@ -73,4 +74,5 @@ class ViewerController extends ControllerBase {
 
         return $response;
     }
+
 }

--- a/src/Controller/ViewerController.php
+++ b/src/Controller/ViewerController.php
@@ -49,7 +49,7 @@ class ViewerController extends ControllerBase {
      *
      * @return Response
      */
-    public function editor(Media $media, $edit = false) {
+    public function editor(Media $media, $edit = FALSE) {
         $options = [
             'closebutton' => 'true',
         ];

--- a/src/Controller/ViewerController.php
+++ b/src/Controller/ViewerController.php
@@ -56,7 +56,7 @@ class ViewerController extends ControllerBase {
 
         $render_array = CoolUtils::getViewerRender($media, $edit, $options);
 
-        if (!$render_array ||  array_key_exists('error', $render_array)) {
+        if (!$render_array || array_key_exists('error', $render_array)) {
             $error_msg = 'Viewer error: ' . ($render_array ? $render_array['error'] : 'NULL');
             \Drupal::logger('cool')->error($error_msg);
             return new Response(

--- a/src/Controller/WopiController.php
+++ b/src/Controller/WopiController.php
@@ -44,7 +44,7 @@ class WopiController extends ControllerBase {
         $token = $request->query->get('access_token');
 
         $jwt_payload = CoolUtils::verifyTokenForId($token, $id);
-        if ($jwt_payload == null) {
+        if ($jwt_payload == NULL) {
             return static::permissionDenied();
         }
 
@@ -101,7 +101,7 @@ class WopiController extends ControllerBase {
         $token = $request->query->get('access_token');
 
         $jwt_payload = CoolUtils::verifyTokenForId($token, $id);
-        if ($jwt_payload == null) {
+        if ($jwt_payload == NULL) {
             return static::permissionDenied();
         }
 
@@ -129,7 +129,7 @@ class WopiController extends ControllerBase {
         $exitsave = $request->headers->get('x-cool-wopi-isexitsave') == 'true';
 
         $jwt_payload = CoolUtils::verifyTokenForId($token, $id);
-        if ($jwt_payload == null || !$jwt_payload->wri) {
+        if ($jwt_payload == NULL || !$jwt_payload->wri) {
             return static::permissionDenied();
         }
 

--- a/src/Controller/WopiController.php
+++ b/src/Controller/WopiController.php
@@ -151,7 +151,7 @@ class WopiController extends ControllerBase {
                 \Drupal::logger('cool')->error('Conflict saving file ' . $id . ' wopi: ' . $wopi_stamp->format('c') . ' differs from file: ' . $file_stamp->format('c'));
 
                 return new Response(
-                    json_encode([ 'COOLStatusCode' => 1010 ]),
+                    json_encode(['COOLStatusCode' => 1010]),
                     Response::HTTP_CONFLICT,
                     ['content-type' => 'application/json'],
                 );
@@ -191,13 +191,13 @@ class WopiController extends ControllerBase {
             $reasons[] = 'Save on Exit';
         }
         if (count($reasons) > 0) {
-            $save_reason .= ' (' . implode(', ', $reasons)  . ')';
+            $save_reason .= ' (' . implode(', ', $reasons) . ')';
         }
         \Drupal::logger('cool')->error('Save reason: ' . $save_reason);
         $media->setRevisionLogMessage($save_reason);
         $media->save();
 
-        $payload =  json_encode([
+        $payload = json_encode([
             'LastModifiedTime' => $mtime->format('c'),
         ]);
 

--- a/src/Controller/WopiController.php
+++ b/src/Controller/WopiController.php
@@ -32,7 +32,7 @@ class WopiController extends ControllerBase {
      * @return \Symfony\Component\HttpFoundation\Response
      *   Response object.
      */
-    static function permissionDenied(): Response {
+    public static function permissionDenied(): Response {
         return new Response(
             'Authentication failed.',
             Response::HTTP_FORBIDDEN,
@@ -40,7 +40,7 @@ class WopiController extends ControllerBase {
         );
     }
 
-    function wopiCheckFileInfo(string $id, Request $request) {
+    public function wopiCheckFileInfo(string $id, Request $request) {
         $token = $request->query->get('access_token');
 
         $jwt_payload = CoolUtils::verifyTokenForId($token, $id);
@@ -97,7 +97,7 @@ class WopiController extends ControllerBase {
         return $response;
     }
 
-    function wopiGetFile(string $id, Request $request) {
+    public function wopiGetFile(string $id, Request $request) {
         $token = $request->query->get('access_token');
 
         $jwt_payload = CoolUtils::verifyTokenForId($token, $id);
@@ -121,7 +121,7 @@ class WopiController extends ControllerBase {
         return $response;
     }
 
-    function wopiPutFile(string $id, Request $request) {
+    public function wopiPutFile(string $id, Request $request) {
         $token = $request->query->get('access_token');
         $timestamp = $request->headers->get('x-cool-wopi-timestamp');
         $modified_by_user = $request->headers->get('x-cool-wopi-ismodifiedbyuser') == 'true';

--- a/src/Controller/WopiController.php
+++ b/src/Controller/WopiController.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright the Collabora Online contributors.
  *
@@ -224,8 +225,10 @@ class WopiController extends ControllerBase {
         switch ($action) {
             case 'info':
                 return $this->wopiCheckFileInfo($id, $request);
+
             case 'content':
                 return $this->wopiGetFile($id, $request);
+
             case 'save':
                 return $this->wopiPutFile($id, $request);
         }
@@ -237,4 +240,5 @@ class WopiController extends ControllerBase {
         );
         return $response;
     }
+
 }

--- a/src/Controller/WopiController.php
+++ b/src/Controller/WopiController.php
@@ -222,15 +222,12 @@ class WopiController extends ControllerBase {
     public function wopi(string $action, string $id, Request $request) {
         $returnCode = Response::HTTP_BAD_REQUEST;
         switch ($action) {
-        case 'info':
-            return $this->wopiCheckFileInfo($id, $request);
-            break;
-        case 'content':
-            return $this->wopiGetFile($id, $request);
-            break;
-        case 'save':
-            return $this->wopiPutFile($id, $request);
-            break;
+            case 'info':
+                return $this->wopiCheckFileInfo($id, $request);
+            case 'content':
+                return $this->wopiGetFile($id, $request);
+            case 'save':
+                return $this->wopiPutFile($id, $request);
         }
 
         $response = new Response(

--- a/src/Cool/CoolRequest.php
+++ b/src/Cool/CoolRequest.php
@@ -83,36 +83,36 @@ class CoolRequest {
         $wopi_client_server = $default_config->get('cool')['server'];
         if (!$wopi_client_server) {
             $this->error_code = 201;
-            return;
+            return NULL;
         }
         $wopi_client_server = trim($wopi_client_server);
 
         if (!strStartsWith($wopi_client_server, 'http')) {
             $this->error_code = 204;
-            return;
+            return NULL;
         }
 
         if (!strStartsWith($wopi_client_server, $_HOST_SCHEME . '://')) {
             $this->error_code = 202;
-            return;
+            return NULL;
         }
 
         $discovery = getDiscovery($wopi_client_server);
         if ($discovery === false) {
             $this->error_code = 203;
-            return;
+            return NULL;
         }
 
         $discovery_parsed = simplexml_load_string($discovery);
         if (!$discovery_parsed) {
             $this->error_code = 102;
-            return;
+            return NULL;
         }
 
         $this->wopi_src = strval(getWopiSrcUrl($discovery_parsed, 'text/plain')[0]);
         if (!$this->wopi_src) {
             $this->error_code = 103;
-            return;
+            return NULL;
         }
 
         return $this->wopi_src;

--- a/src/Cool/CoolRequest.php
+++ b/src/Cool/CoolRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright the Collabora Online contributors.
  *
@@ -117,4 +118,5 @@ class CoolRequest {
 
         return $this->wopi_src;
     }
+
 }

--- a/src/Cool/CoolRequest.php
+++ b/src/Cool/CoolRequest.php
@@ -21,8 +21,8 @@ function getDiscovery($server) {
     $discovery_url = $server . '/hosting/discovery';
 
     $default_config = \Drupal::config('collabora_online.settings');
-    if ($default_config === null) {
-        return false;
+    if ($default_config === NULL) {
+        return FALSE;
     }
     $disable_checks = (bool) $default_config->get('cool')['disable_cert_check'];
 
@@ -36,14 +36,14 @@ function getDiscovery($server) {
 }
 
 function getWopiSrcUrl($discovery_parsed, $mimetype) {
-    if ($discovery_parsed === null || $discovery_parsed == false) {
-        return null;
+    if ($discovery_parsed === NULL || $discovery_parsed == FALSE) {
+        return NULL;
     }
     $result = $discovery_parsed->xpath(sprintf('/wopi-discovery/net-zone/app[@name=\'%s\']/action', $mimetype));
     if ($result && count($result) > 0) {
         return $result[0]['urlsrc'];
     }
-    return null;
+    return NULL;
 }
 
 function strStartsWith($s, $ss) {
@@ -99,7 +99,7 @@ class CoolRequest {
         }
 
         $discovery = getDiscovery($wopi_client_server);
-        if ($discovery === false) {
+        if ($discovery === FALSE) {
             $this->error_code = 203;
             return NULL;
         }

--- a/src/Cool/CoolRequest.php
+++ b/src/Cool/CoolRequest.php
@@ -18,13 +18,13 @@ namespace Drupal\collabora_online\Cool;
  * Return `false` in case of error.
  */
 function getDiscovery($server) {
-    $discovery_url = $server.'/hosting/discovery';
+    $discovery_url = $server . '/hosting/discovery';
 
     $default_config = \Drupal::config('collabora_online.settings');
     if ($default_config === null) {
         return false;
     }
-    $disable_checks = (bool)$default_config->get('cool')['disable_cert_check'];
+    $disable_checks = (bool) $default_config->get('cool')['disable_cert_check'];
 
     $stream_context = stream_context_create([
         'ssl' => [

--- a/src/Cool/CoolRequest.php
+++ b/src/Cool/CoolRequest.php
@@ -30,8 +30,9 @@ function getDiscovery($server) {
         'ssl' => [
             'verify_peer'       => !$disable_checks,
             'verify_peer_name'  => !$disable_checks,
-        ]]);
-    $res = file_get_contents($discovery_url, false, $stream_context);
+        ],
+    ]);
+    $res = file_get_contents($discovery_url, FALSE, $stream_context);
     return $res;
 }
 

--- a/src/Cool/CoolRequest.php
+++ b/src/Cool/CoolRequest.php
@@ -63,7 +63,7 @@ class CoolRequest {
         203 => 'Not able to retrieve the discovery.xml file from the Collabora Online server.',
         102 => 'The retrieved discovery.xml file is not a valid XML file.',
         103 => 'The requested mime type is not handled.',
-        204 => 'Warning! You have to specify the scheme protocol too (http|https) for the server address.'
+        204 => 'Warning! You have to specify the scheme protocol too (http|https) for the server address.',
     ];
 
     private $wopi_src;

--- a/src/Cool/CoolUtils.php
+++ b/src/Cool/CoolUtils.php
@@ -29,6 +29,7 @@ class CoolUtils {
 
     /** Get the file based on the entity id */
     public static function getFileById($id) {
+        /** @var \Drupal\media\MediaInterface|null $media */
         $media = \Drupal::entityTypeManager()->getStorage('media')->load($id);
         return CoolUtils::getFile($media);
     }

--- a/src/Cool/CoolUtils.php
+++ b/src/Cool/CoolUtils.php
@@ -67,7 +67,8 @@ class CoolUtils {
             if ($payload && ($payload->fid == $id) && ($payload->exp >= gettimeofday(true))) {
                 return $payload;
             }
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             \Drupal::logger('cool')->error($e->getMessage());
         }
         return null;
@@ -142,7 +143,8 @@ class CoolUtils {
     public static function getEditorUrl(Media $media, $can_write = false) {
         if ($can_write) {
             return Url::fromRoute('collabora-online.edit', ['media' => $media->id()]);
-        } else {
+        }
+        else {
             return Url::fromRoute('collabora-online.view', ['media' => $media->id()]);
         }
     }

--- a/src/Cool/CoolUtils.php
+++ b/src/Cool/CoolUtils.php
@@ -41,7 +41,7 @@ class CoolUtils {
     }
 
     /** Obtain the signing key from the key storage */
-    static function getKey() {
+    public static function getKey() {
         $default_config = \Drupal::config('collabora_online.settings');
         $key_id = $default_config->get('cool')['key_id'];
 

--- a/src/Cool/CoolUtils.php
+++ b/src/Cool/CoolUtils.php
@@ -58,7 +58,7 @@ class CoolUtils {
     public static function verifyTokenForId(
         #[\SensitiveParameter]
         string $token,
-        $id
+        $id,
     ) {
         $key = static::getKey();
         try {

--- a/src/Cool/CoolUtils.php
+++ b/src/Cool/CoolUtils.php
@@ -188,7 +188,8 @@ class CoolUtils {
             '#wopiClient' => $wopi_client,
             '#wopiSrc' => urlencode($wopi_base . '/cool/wopi/files/' . $id),
             '#accessToken' => $access_token,
-            '#accessTokenTtl' => $ttl * 1000, // It's in usec. The JWT is in sec.
+            // It's in usec. The JWT is in sec.
+            '#accessTokenTtl' => $ttl * 1000,
             '#allowfullscreen' => $allowfullscreen ? 'allowfullscreen' : '',
         ];
         if ($options) {

--- a/src/Cool/CoolUtils.php
+++ b/src/Cool/CoolUtils.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright the Collabora Online contributors.
  *
@@ -196,6 +197,5 @@ class CoolUtils {
 
         return $render_array;
     }
-
 
 }

--- a/src/Cool/CoolUtils.php
+++ b/src/Cool/CoolUtils.php
@@ -64,14 +64,14 @@ class CoolUtils {
         try {
             $payload = JWT::decode($token, new Key($key, 'HS256'));
 
-            if ($payload && ($payload->fid == $id) && ($payload->exp >= gettimeofday(true))) {
+            if ($payload && ($payload->fid == $id) && ($payload->exp >= gettimeofday(TRUE))) {
                 return $payload;
             }
         }
         catch (\Exception $e) {
             \Drupal::logger('cool')->error($e->getMessage());
         }
-        return null;
+        return NULL;
     }
 
     /**
@@ -81,7 +81,7 @@ class CoolUtils {
         $default_config = \Drupal::config('collabora_online.settings');
         $ttl = $default_config->get('cool')['access_token_ttl'];
 
-        return gettimeofday(true) + $ttl;
+        return gettimeofday(TRUE) + $ttl;
     }
 
     /**
@@ -116,9 +116,9 @@ class CoolUtils {
      *  accept.
      */
     const READ_ONLY = [
-        'application/x-iwork-keynote-sffkey' => true,
-        'application/x-iwork-pages-sffpages' => true,
-        'application/x-iwork-numbers-sffnumbers' => true,
+        'application/x-iwork-keynote-sffkey' => TRUE,
+        'application/x-iwork-pages-sffpages' => TRUE,
+        'application/x-iwork-numbers-sffnumbers' => TRUE,
     ];
 
     /**
@@ -140,7 +140,7 @@ class CoolUtils {
     }
 
     /** Return the editor / viewer Drupal URL from the routes configured. */
-    public static function getEditorUrl(Media $media, $can_write = false) {
+    public static function getEditorUrl(Media $media, $can_write = FALSE) {
         if ($can_write) {
             return Url::fromRoute('collabora-online.edit', ['media' => $media->id()]);
         }
@@ -163,14 +163,14 @@ class CoolUtils {
      *   Options for the renderer. Current values:
      *     - "closebutton" if "true" will add a close box. (see COOL SDK)
      */
-    public static function getViewerRender(Media $media, bool $can_write, $options = null) {
+    public static function getViewerRender(Media $media, bool $can_write, $options = NULL) {
         $default_config = \Drupal::config('collabora_online.settings');
         $wopi_base = $default_config->get('cool')['wopi_base'];
         $allowfullscreen = $default_config->get('cool')['allowfullscreen'] ?? FALSE;
 
         $req = new CoolRequest();
         $wopi_client = $req->getWopiClientURL();
-        if ($wopi_client === null) {
+        if ($wopi_client === NULL) {
             return [
                 'error' => t('The Collabora Online server is not available: ') . $req->errorString(),
             ];

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -31,7 +31,7 @@ class ConfigForm extends ConfigFormBase {
      */
     public function getEditableConfigNames() {
         return [
-            static::SETTINGS
+            static::SETTINGS,
         ];
     }
 

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -100,6 +100,6 @@ class ConfigForm extends ConfigFormBase {
             ->save();
 
         parent::submitForm($form, $form_state);
-  }
+    }
 
 }

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright the Collabora Online contributors.
  *
@@ -100,4 +101,5 @@ class ConfigForm extends ConfigFormBase {
 
         parent::submitForm($form, $form_state);
   }
+
 }

--- a/src/Plugin/Field/FieldFormatter/CoolPreview.php
+++ b/src/Plugin/Field/FieldFormatter/CoolPreview.php
@@ -43,6 +43,7 @@ class CoolPreview extends EntityReferenceFormatterBase {
      * {@inheritdoc}
      */
     public function viewElements(FieldItemListInterface $items, $langcode) {
+        /** @var \Drupal\Core\Field\EntityReferenceFieldItemListInterface $items */
         $elements = [];
         $media = $items->getEntity();
         if (!$media instanceof MediaInterface) {

--- a/src/Plugin/Field/FieldFormatter/CoolPreview.php
+++ b/src/Plugin/Field/FieldFormatter/CoolPreview.php
@@ -62,7 +62,7 @@ class CoolPreview extends EntityReferenceFormatterBase {
         }
 
         foreach ($this->getEntitiesToView($items, $langcode) as $delta => $file) {
-            $url = CoolUtils::getEditorUrl($media, false);
+            $url = CoolUtils::getEditorUrl($media, FALSE);
 
             $render_array = [
                 '#editorUrl' => $url,

--- a/src/Plugin/Field/FieldFormatter/CoolPreview.php
+++ b/src/Plugin/Field/FieldFormatter/CoolPreview.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright the Collabora Online contributors.
  *
@@ -74,4 +75,5 @@ class CoolPreview extends EntityReferenceFormatterBase {
         }
         return $elements;
     }
+
 }

--- a/tests/src/ExistingSiteJavascript/CollaboraIntegrationTest.php
+++ b/tests/src/ExistingSiteJavascript/CollaboraIntegrationTest.php
@@ -7,7 +7,6 @@ namespace Drupal\Tests\collabora_online\ExistingSiteJavascript;
 use Drupal\file\Entity\File;
 use Drupal\media\Entity\Media;
 use Drupal\media\MediaInterface;
-use WebDriver\Exception\StaleElementReference;
 use weitzman\DrupalTestTraits\ExistingSiteSelenium2DriverTestBase;
 
 /**

--- a/tests/src/ExistingSiteJavascript/CollaboraIntegrationTest.php
+++ b/tests/src/ExistingSiteJavascript/CollaboraIntegrationTest.php
@@ -40,14 +40,14 @@ class CollaboraIntegrationTest extends ExistingSiteSelenium2DriverTestBase {
 
         $document_field = $assert_session->waitForElement('css', 'input#document-name-input');
         $this->assertNotNull($document_field, 'The document name input was not found after 10 seconds.');
-        $this->getCurrentPage()->waitFor(10, function() use ($document_field) {
+        $this->getCurrentPage()->waitFor(10, function () use ($document_field) {
           return $document_field->getValue() === 'shopping-list.txt';
         });
         $this->assertEquals('shopping-list.txt', $document_field->getValue(), 'The document name input did not contain the correct value after 10 seconds.');
 
         $word_count_element = $assert_session->waitForElement('css', 'div#StateWordCount');
         $this->assertNotNull($word_count_element, 'The word count element was not found after 10 seconds.');
-        $this->getCurrentPage()->waitFor(10, function() use ($word_count_element) {
+        $this->getCurrentPage()->waitFor(10, function () use ($word_count_element) {
           return $word_count_element->getText() === '2 words, 18 characters';
         });
         $this->assertEquals('2 words, 18 characters', $word_count_element->getText(), 'The word count element did not contain the correct text after 10 seconds.');

--- a/tests/src/Functional/AccessTest.php
+++ b/tests/src/Functional/AccessTest.php
@@ -187,7 +187,7 @@ class AccessTest extends BrowserTestBase {
      *   An array of paths, or NULL to just use the array keys from $expected.
      *   This parameter is useful if the paths all look very similar.
      */
-    protected function assertPathsAccessByUsers(array $expected, array $accounts, array $paths = NULL): void {
+    protected function assertPathsAccessByUsers(array $expected, array $accounts, ?array $paths = NULL): void {
         if ($paths === NULL) {
             $paths = array_keys($expected);
             $paths = array_combine($paths, $paths);

--- a/tests/src/Functional/AccessTest.php
+++ b/tests/src/Functional/AccessTest.php
@@ -135,7 +135,7 @@ class AccessTest extends BrowserTestBase {
             'diary keeper' => $this->createUser([
                 // There is no 'preview own *' permission in this module.
                 'preview diary in collabora',
-                'edit own diary in collabora'
+                'edit own diary in collabora',
             ]),
         ];
 

--- a/tests/src/Functional/AccessTest.php
+++ b/tests/src/Functional/AccessTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright the Collabora Online contributors.
  *

--- a/tests/src/Functional/PermissionTest.php
+++ b/tests/src/Functional/PermissionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright the Collabora Online contributors.
  *


### PR DESCRIPTION
See #43.

This is the first batch of changes.
Comments will in a separate PR, as requested.

The branch history is intentionally crafted.
I very much recommend to keep all the commits and do a real merge without fast-forward, so we end up with a topology like this:
```
*   8fd5586e (HEAD -> main) Merge branch 'issue-43-phpcs-no-comment-changes'
|\  
| * 798c6ecd Issue #43: Run phpcs in github action.
| * b747ed3f Issue #43: Add customized phpcs.xml that passes.
| * 8af7c0c0 Issue #43: Put array closing bracket on new line.
| * 4f42690d Issue #43: Fix indentation to current package standard.
| * 277cadd9 Issue #43: Mark parameter as nullable if it has NULL default value.
| * f45e07c5 Issue #43: Remove unused imports.
| * 4e688c91 Issue #43: Fix inline comments.
| * 9f20c974 Issue #43: Put inline comment on separate line.
| * 6bffeeec Issue #43: NULL, TRUE and FALSE in uppercase.
| * 1cce6a79 Issue #43: Add public access modifier.
| * be5117af Issue #43: Normalize spaces.
| * 40cf78a1 Issue #43: Add trailing comma.
| * 0f72055e Issue #43: Put catch and else on new line.
| * d8e31c21 Issue #43: Normalize blank lines.
| * 6af7e21f Issue #43: Remove unreachable break in switch, fix indentation.
| * 7fe14273 Issue #43: Explicitly return NULL, to avoid inconsistent return points.
| * 7a29f610 Issue #43: Add inline `@var` doc for static analysis.
|/  
*
```
This preserves the commits, but makes it clear that they are part of their own branch.