### PR TITLE
Ensure package name matches Drupal standards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "collabora/online",
+    "name": "drupal/collabora_online",
     "type": "drupal-module",
     "description": "Collabora Online connector for Drupal",
     "license": "MPL-2.0",


### PR DESCRIPTION
Drupal's packagist will rename packages it serves to match format `drupal/<project-name>` where `<project-name>` is the slug of the Project page on Drupal.org (https://www.drupal.org/project/collabora_online).

This means that within the Drupal community this package is available as `drupal/collabora_online`. However, trying to pull this in from GitHub (e.g. because you need a specific branch, an unsynced version, or a temporary fork for development) will make composer think this is an entirely separate package.

To solve this the package on GitHub is renamed to how it'll be shared with the Drupal community. This helps composer understand that regardless of its origin the package is the same.