### PR TITLE
Add copyright notice in php files.

### DIFF
--- a/modules/collabora_online_group/src/Plugin/Group/RelationHandler/CollaboraAccessControl.php
+++ b/modules/collabora_online_group/src/Plugin/Group/RelationHandler/CollaboraAccessControl.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 declare(strict_types=1);
 
 namespace Drupal\collabora_online_group\Plugin\Group\RelationHandler;

--- a/modules/collabora_online_group/src/Plugin/Group/RelationHandler/CollaboraPermissionProvider.php
+++ b/modules/collabora_online_group/src/Plugin/Group/RelationHandler/CollaboraPermissionProvider.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 declare(strict_types=1);
 
 namespace Drupal\collabora_online_group\Plugin\Group\RelationHandler;

--- a/modules/collabora_online_group/tests/src/Functional/GroupMediaViewsTest.php
+++ b/modules/collabora_online_group/tests/src/Functional/GroupMediaViewsTest.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 declare(strict_types=1);
 
 namespace Drupal\Tests\collabora_online_group\Functional;

--- a/modules/collabora_online_group/tests/src/Kernel/AccessTest.php
+++ b/modules/collabora_online_group/tests/src/Kernel/AccessTest.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 declare(strict_types=1);
 
 namespace Drupal\Tests\collabora_online_group\Kernel;

--- a/modules/collabora_online_group/tests/src/Kernel/PermissionTest.php
+++ b/modules/collabora_online_group/tests/src/Kernel/PermissionTest.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 declare(strict_types=1);
 
 namespace Drupal\Tests\collabora_online_group\Kernel;

--- a/modules/collabora_online_group/tests/src/Traits/GroupRelationTrait.php
+++ b/modules/collabora_online_group/tests/src/Traits/GroupRelationTrait.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 declare(strict_types=1);
 
 namespace Drupal\Tests\collabora_online_group\Traits;

--- a/src/Plugin/views/field/CollaboraEdit.php
+++ b/src/Plugin/views/field/CollaboraEdit.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 declare(strict_types=1);
 
 namespace Drupal\collabora_online\Plugin\views\field;

--- a/src/Plugin/views/field/CollaboraPreview.php
+++ b/src/Plugin/views/field/CollaboraPreview.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 declare(strict_types=1);
 
 namespace Drupal\collabora_online\Plugin\views\field;

--- a/tests/src/ExistingSiteJavascript/CollaboraIntegrationTest.php
+++ b/tests/src/ExistingSiteJavascript/CollaboraIntegrationTest.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 declare(strict_types=1);
 
 namespace Drupal\Tests\collabora_online\ExistingSiteJavascript;

--- a/tests/src/Kernel/CollaboraMediaAccessTest.php
+++ b/tests/src/Kernel/CollaboraMediaAccessTest.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 declare(strict_types=1);
 
 namespace Drupal\Tests\collabora_online\Kernel;

--- a/tests/src/Kernel/ViewsLinkFieldsTest.php
+++ b/tests/src/Kernel/ViewsLinkFieldsTest.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 declare(strict_types=1);
 
 namespace Drupal\Tests\collabora_online\Kernel;

--- a/tests/src/Traits/MediaCreationTrait.php
+++ b/tests/src/Traits/MediaCreationTrait.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 declare(strict_types=1);
 
 namespace Drupal\Tests\collabora_online\Traits;


### PR DESCRIPTION
In some php files we forgot to add a copyright notice.
We are still discussing if it is needed, see discussion in #43.

I am opening this PR, but we could determine that we don't need it.