### PR TITLE
Automatically generate WOPI proof key when starting the development setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,13 +61,6 @@ jobs:
         run: |
           docker-compose exec -T web ./vendor/bin/phpcs -s
 
-      - name: Generate proof key
-        run: |
-          set -x
-          docker-compose exec -T collabora coolconfig generate-proof-key
-          # Collabora becomes unavailable after the above command.
-          docker-compose restart collabora
-
       - name: Drupal site install
         run: |
           docker-compose exec -T web ./vendor/bin/run drupal:site-install

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ For a local demo or test installation, [see below](#development--demo-installati
 It is recommended to generate a proof key as documented here:\
 https://sdk.collaboraonline.com/docs/advanced_integration.html#wopi-proof
 
-If not, the proof mechanism needs to be disabled in the module settings.
+If not, the proof mechanism needs to be disabled in the module settings.\
+The Docker setup provided automatically generates a proof key at startup.
 
 ### Module installation steps
 
@@ -77,8 +78,6 @@ docker-compose up -d
 docker-compose exec web composer install
 docker-compose exec web ./vendor/bin/run drupal:site-install
 
-docker-compose exec collabora coolconfig generate-proof-key
-docker-compose restart collabora
 ```
 
 Optionally, generate an admin login link.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,14 @@ services:
         --o:storage.wopi.alias_groups.group[0].host=http://web.test \
         --o:storage.wopi.alias_groups.group[0].host[@allow]=true \
         --o:storage.wopi.alias_groups.group[0].alias[0]=http://localhost"
+    # Manually generate the proof key, replicating the behavior of "coolconfig generate-proof-key".
+    command:
+      - sh
+      - -c
+      - >
+        openssl genpkey -algorithm RSA -out /etc/coolwsd/proof_key -pkeyopt rsa_keygen_bits:2048 &&
+        openssl rsa -in /etc/coolwsd/proof_key -outform PEM -pubout -out /etc/coolwsd/proof_key.pub &&
+        /start-collabora-online.sh
 
 volumes:
   mysql:


### PR DESCRIPTION
At the moment, for local development we are required to run manually the commands
```
coolconfig generate-proof-key
docker compose restart collabora
```
We can automatise this as it was done for Drupal CI pipelines.