### PR TITLE
Close the welcome popup in tests, when it occurs.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ phpunit:
     - !reference [.with-database]
     - !reference [.with-chrome]
     - !reference [.with-chrome-legacy]
-    - name: collabora/code
+    - name: collabora/code:24.04.11.3.1
       alias: 'collabora.test'
       variables:
         username: admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - '7900:7900'
 
   collabora:
-    image: collabora/code
+    image: collabora/code:24.04.11.3.1
     ports:
       - '9980:9980'
     networks:

--- a/tests/src/ExistingSiteJavascript/CollaboraIntegrationTest.php
+++ b/tests/src/ExistingSiteJavascript/CollaboraIntegrationTest.php
@@ -82,6 +82,21 @@ class CollaboraIntegrationTest extends ExistingSiteSelenium2DriverTestBase {
     // visible on a mobile / touch device.
     $this->assertWaitForElement('#mobile-edit-button');
 
+    // Detect if Collabora shows a welcome dialog.
+    if ($this->getCurrentPage()->find('css', '[name=iframe-welcome-form]')) {
+      // The contents of the welcome dialog are in an iframe.
+      $this->getSession()->switchToIFrame('iframe-welcome-form');
+      // Click the close button of the welcome dialog.
+      // The close button itself has dimensions 0x0 and is regarded as not
+      // clickable by Selenium. It contains a ::before pseudo-element with
+      // non-zero dimensions which would receive the click.
+      // To not have to think about this, just click with js.
+      $this->getSession()->executeScript("document.querySelector('div#welcome-close').click();");
+      // Switch back to the previous iframe.
+      $this->getSession()->switchToIFrame(NULL);
+      $this->getSession()->switchToIFrame('collabora-online-viewer');
+    }
+
     // Switch to 'File' menu where 'Rename' button should be.
     $assert_session = $this->assertSession();
     $assert_session->buttonExists('File')->click();


### PR DESCRIPTION
CollaboraOnline will show a welcome popup on first visit _sometimes_.\
I think it happens when there is a new version, and it decides that it needs to tell the user. Not sure the exact condition.

This causes a problem with ExistingSiteJavascript tests that assert that the editor shows up correctly.\
We saw it in Drupal CI.\
https://git.drupalcode.org/project/collabora_online/-/pipelines/446841/test_report?job_name=phpunit

```
Drupal\Tests\collabora_online\ExistingSiteJavascript\CollaboraIntegrationTest::testCollaboraEdit
WebDriver\Exception\ElementClickIntercepted: element click intercepted: Element <button class="ui-tab notebookbar" id="...-tab-label" role="tab" aria-label="File" aria-selected="false" tabindex="-1" title="Tap to collapse">File</button> is not clickable at point (51, 20). Other element would receive the click: <div class="iframe-welcome-content">...</div>
  (Session info: chrome-headless-shell=123.0.6312.58)

/builds/project/collabora_online/vendor/lullabot/php-webdriver/lib/WebDriver/Exception.php:198
/builds/project/collabora_online/vendor/lullabot/php-webdriver/lib/WebDriver/AbstractWebDriver.php:227
/builds/project/collabora_online/vendor/lullabot/php-webdriver/lib/WebDriver/AbstractWebDriver.php:287
/builds/project/collabora_online/vendor/lullabot/php-webdriver/lib/WebDriver/Container.php:231
/builds/project/collabora_online/vendor/lullabot/mink-selenium2-driver/src/Selenium2Driver.php:861
/builds/project/collabora_online/vendor/lullabot/mink-selenium2-driver/src/Selenium2Driver.php:853
/builds/project/collabora_online/vendor/behat/mink/src/Element/NodeElement.php:176
/builds/project/collabora_online/tests/src/ExistingSiteJavascript/CollaboraIntegrationTest.php:87
/builds/project/collabora_online/vendor/bin/phpunit:122
```

This PR adds something to the test to close the popup if it occurs.

It also contains another change that fixes the Collabora version.
We found issues with a recent update.

@hfiguiere Would be interesting to know the conditions for when this occurs, and if our selector is reliable and will be supported in the future.