### PR TITLE
Relax dependency to not break existing keys.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=8.1",
         "drupal/key": "^1.19",
-        "firebase/php-jwt": "^7",
+        "firebase/php-jwt": "^6.10 || ^7",
         "phpseclib/phpseclib": "^3.0",
         "symfony/error-handler": "^6.4 || ^7.1"
     },

--- a/composer.legacy.json
+++ b/composer.legacy.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=8.1",
         "drupal/key": "^1.19",
-        "firebase/php-jwt": "^7",
+        "firebase/php-jwt": "^6.10 || ^7",
         "phpseclib/phpseclib": "^3.0",
         "symfony/error-handler": "^6.4 || ^7.1"
     },


### PR DESCRIPTION
In #125 I updated `firebase/php-jwt` to 7.x version due to a CVE.
This means that short, invalid keys would break without warning.
While we are on a 0.x version and we are allowed a bit of flexibility over BC changes, and even if this is not strictly a BC change from our module but a security update of a dependency, we discussed with @donquixote and agreed to relax the dependency, removing the 6.x support when we make a new major.